### PR TITLE
Use config file for setuptools

### DIFF
--- a/predictiveness_curve/__init__.py
+++ b/predictiveness_curve/__init__.py
@@ -2,7 +2,7 @@ from .base import calculate_enrichment_factor
 from .base import convert_label_to_zero_or_one
 from .base import plot_predictiveness_curve
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 
 __all__ = [
     'calculate_enrichment_factor',

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,18 @@
+[metadata]
+name = predictiveness-curve
+version = attr: predictiveness_curve.__version__
+url = https://github.com/yamasakih/predictiveness-curve
+license = MIT
+author = Hiroyuki Yamasaki
+author_email = yamasaki.phone@gmail.com
+description = Plot predictiveness curve
+long_description = file: README.md
+long_description_content_type = text/markdown
+classifiers = License :: OSI Approved :: MIT License
+
+[options]
+py_modules = predictiveness_curve
+python_requires = >=3.6
+install_requires = 
+    matplotlib
+    numpy

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,3 @@
 from setuptools import setup
 
-__version__ = '0.2.1'
-
-with open("README.md") as f:
-    long_description = f.read()
-
-setup(
-    name='predictiveness-curve',
-    version=__version__,
-    url='https://github.com/yamasakih/predictiveness-curve',
-    license='MIT',
-    py_modules=['predictiveness_curve'],
-    python_requires='>=3.6',
-    author='Hiroyuki Yamasaki',
-    author_email='yamasaki.phone@gmail.com',
-    install_requires=['matplotlib', 'numpy'],
-    description='Plot predictiveness curve',
-    long_description=long_description,
-    long_description_content_type='text/markdown',
-    classifiers=['License :: OSI Approved :: MIT License',]
-)
+setup()


### PR DESCRIPTION
## Overview
Fix #34 
Use `setup.cfg` instead of `setuptools.setup()` options.

## Pros
- Simple `setup.py`.
- Use `predictiveness_curve.__init__.__version__` for project version.
  - change this vars when bump the version.